### PR TITLE
Modify podspec to avoid globbing umbrella header in source_files

### DIFF
--- a/BaseTask.podspec
+++ b/BaseTask.podspec
@@ -20,5 +20,5 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = "9.0"
 
   s.source       = {git: "https://github.com/endoze/BaseTask.git", tag: "#{s.version}"}
-  s.source_files  = ["BaseTask/*.swift", "BaseTask/*.{h,m}"]
+  s.source_files  = ["BaseTask/*.swift", "BaseTask/BaseTaskObjC.{h,m}"]
 end


### PR DESCRIPTION
In order to ensure the podspec validates and avoid grouping the umbrella
header into the source_files of the podspec, this commit replaces the
file glob with a more specific one.
